### PR TITLE
show IP address on GUI devices

### DIFF
--- a/ui/ip-address.qml
+++ b/ui/ip-address.qml
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 by Aditya Mehra <aix.m@outlook.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import QtQuick.Layouts 1.4
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+import org.kde.kirigami 2.4 as Kirigami
+
+import Mycroft 1.0 as Mycroft
+
+Mycroft.Delegate {
+    id: root
+    property var ip: sessionData.ip
+    Rectangle {
+        color: "#22a7f0"
+        width: parent.width
+        height: parent.height
+        ColumnLayout {
+            anchors.fill: parent
+        
+            Text {
+                id: instruction
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignLeft
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WordWrap
+                elide: Text.ElideRight
+                font.family: "Noto Sans"
+                font.bold: true
+                font.weight: Font.Bold
+                fontSizeMode: Text.HorizontalFit
+                minimumPixelSize: 65
+                font.pixelSize: 80
+                visible: !content.visible
+                color: "white"
+                text: root.ip
+            }
+        }
+    }
+}

--- a/ui/ip-address.qml
+++ b/ui/ip-address.qml
@@ -17,38 +17,16 @@
 
 import QtQuick.Layouts 1.4
 import QtQuick 2.4
-import QtQuick.Controls 2.0
-import org.kde.kirigami 2.4 as Kirigami
 
 import Mycroft 1.0 as Mycroft
 
-Mycroft.Delegate {
+Mycroft.ProportionalDelegate {
     id: root
-    property var ip: sessionData.ip
-    Rectangle {
-        color: "#22a7f0"
-        width: parent.width
-        height: parent.height
-        ColumnLayout {
-            anchors.fill: parent
-        
-            Text {
-                id: instruction
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignLeft
-                horizontalAlignment: Text.AlignHCenter
-                wrapMode: Text.WordWrap
-                elide: Text.ElideRight
-                font.family: "Noto Sans"
-                font.bold: true
-                font.weight: Font.Bold
-                fontSizeMode: Text.HorizontalFit
-                minimumPixelSize: 65
-                font.pixelSize: 80
-                visible: !content.visible
-                color: "white"
-                text: root.ip
-            }
-        }
+    Mycroft.AutoFitLabel {
+        id: ipAddress
+        font.weight: Font.Bold
+        Layout.fillWidth: true
+        Layout.margins: 10
+        text: sessionData.ip
     }
 }


### PR DESCRIPTION
Display IP address on GUI devices. 

Re-uses the qml page from Pairing Skill. Currently optimized for landscape orientation. IP address can get split at odd intervals on a portrait screen.

Opted to show whole IP address for "last digit" requests as the voice response provides the shortened information whilst I don't think it adds too much "busyness" to have the whole IP on a screen and provides the assurance that Mycroft is actually talking about the right IP.